### PR TITLE
feat(db): add db helper for mongodb

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -142,6 +142,9 @@
                     "order": "alphabetically"
                 }
             }
-        ]
+        ],
+        // Since mongoDB IDS are accessed using "_id", the eslint throws error for underscore ("_") while accessing the _id.
+        // Hence disbling this rule only for _id.
+        "no-underscore-dangle": ["error", { "allow": ["_id"] }]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,15 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@types/bson": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+            "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.7",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -145,6 +154,16 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
+        },
+        "@types/mongodb": {
+            "version": "3.6.12",
+            "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
+            "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
+            "dev": true,
+            "requires": {
+                "@types/bson": "*",
+                "@types/node": "*"
+            }
         },
         "@types/node": {
             "version": "15.0.1",
@@ -340,6 +359,15 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "bl": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+            "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+            "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+            }
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -358,6 +386,11 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "bson": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+            "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
         },
         "call-bind": {
             "version": "1.0.2",
@@ -449,6 +482,11 @@
             "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
             "dev": true
         },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -483,6 +521,11 @@
             "requires": {
                 "object-keys": "^1.0.12"
             }
+        },
+        "denque": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+            "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -1188,8 +1231,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "inquirer": {
             "version": "8.0.0",
@@ -1321,8 +1363,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -1414,6 +1455,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1458,6 +1505,19 @@
             "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
+            }
+        },
+        "mongodb": {
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
+            "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
+            "requires": {
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
+                "optional-require": "^1.0.2",
+                "safe-buffer": "^5.1.2",
+                "saslprep": "^1.0.0"
             }
         },
         "ms": {
@@ -1563,6 +1623,11 @@
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
+        },
+        "optional-require": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+            "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
         },
         "optionator": {
             "version": "0.9.1",
@@ -1698,6 +1763,11 @@
                 "fast-diff": "^1.1.2"
             }
         },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
         "progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1746,6 +1816,27 @@
             "requires": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
             }
         },
         "regexpp": {
@@ -1819,11 +1910,25 @@
                 "tslib": "^1.9.0"
             }
         },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "requires": {
+                "sparse-bitfield": "^3.0.3"
+            }
         },
         "semver": {
             "version": "7.3.5",
@@ -1904,6 +2009,15 @@
                 }
             }
         },
+        "sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+            "optional": true,
+            "requires": {
+                "memory-pager": "^1.0.2"
+            }
+        },
         "spdx-correct": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -1971,6 +2085,21 @@
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3"
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
             }
         },
         "strip-ansi": {
@@ -2153,6 +2282,11 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "author": "Ashok Chaudhari",
     "homepage": "https://github.com/mr-ashok/modern-nodejs-api-architecture#readme",
     "devDependencies": {
+        "@types/mongodb": "3.6.12",
         "@types/node": "15.0.1",
         "@typescript-eslint/eslint-plugin": "4.9.0",
         "@typescript-eslint/parser": "4.9.0",
@@ -34,5 +35,8 @@
         "eslint-plugin-promise": "4.3.1",
         "prettier": "2.2.1",
         "typescript": "4.1.2"
+    },
+    "dependencies": {
+        "mongodb": "3.6.6"
     }
 }

--- a/src/data/BuildConfig.ts
+++ b/src/data/BuildConfig.ts
@@ -1,0 +1,4 @@
+export default interface BuildConfig {
+    isDebug: boolean;
+    primaryDbConnectionUrl: string;
+}

--- a/src/data/DataDependencies.ts
+++ b/src/data/DataDependencies.ts
@@ -1,0 +1,57 @@
+import BuildConfig from './BuildConfig';
+import CacheManager from './cache/CacheManager';
+import MongoDBConnectionHandler from './db/MongoDBConnectionHandler';
+import { Color, ConsoleFormatter } from './log/ConsoleFormatter';
+import Logger from './log/Logger';
+import LoggerStream from './log/LoggerStream';
+import LoggerStreamImpl from './log/LoggerStreamImpl';
+import TimeWrapper from './TimeWrapper';
+
+type DbHelpers = {};
+
+export type DataDependency = {
+    buildConfig: BuildConfig;
+    cacheManager: CacheManager;
+    dbHelpers: DbHelpers;
+    logger: LoggerStream;
+    timeWrapper: TimeWrapper;
+};
+
+const DB_TAG = new ConsoleFormatter(' DB ')
+    .setTextBold()
+    .setBackgroundColor(Color.Cyan)
+    .setTextColor(Color.Black)
+    .format();
+
+const createDbHelpers = (params: {
+    buildConfig: BuildConfig;
+    cacheManager: CacheManager;
+    logger: LoggerStream;
+    timeWrapper: TimeWrapper;
+}): DbHelpers => {
+    const dbLogger = params.logger.createSubStream(DB_TAG);
+    const dbConnectionHandler = new MongoDBConnectionHandler(dbLogger, params.timeWrapper, params.buildConfig.isDebug);
+    dbConnectionHandler.connectDB(params.buildConfig.primaryDbConnectionUrl);
+
+    return {};
+};
+
+const createDependencies = (buildConfig: BuildConfig): DataDependency => {
+    const timeWrapper = new TimeWrapper();
+    const logger = new Logger(timeWrapper);
+    const loggerStream = new LoggerStreamImpl(logger);
+
+    const cacheManager = new CacheManager(timeWrapper, loggerStream);
+
+    const dbHelpers = createDbHelpers({ logger: loggerStream, timeWrapper, cacheManager, buildConfig });
+
+    return {
+        buildConfig,
+        timeWrapper,
+        logger: loggerStream,
+        cacheManager,
+        dbHelpers,
+    };
+};
+
+export default createDependencies;

--- a/src/data/cache/CacheManager.ts
+++ b/src/data/cache/CacheManager.ts
@@ -1,0 +1,66 @@
+import { Color, ConsoleFormatter } from '../log/ConsoleFormatter';
+import LoggerStream from '../log/LoggerStream';
+import TimeWrapper from '../TimeWrapper';
+
+const DEFAULT_REFRESH_TIME_IN_MIN = 15;
+const CACHE_TAG = new ConsoleFormatter(' Cache ')
+    .setTextBold()
+    .setBackgroundColor(Color.White)
+    .setTextColor(Color.Blue)
+    .format();
+
+export default class CacheManager {
+    private readonly cache: Map<string, { data: unknown; expiry: number; invalidate: boolean }> = new Map();
+    private readonly cacheLogger: LoggerStream;
+
+    constructor(private readonly timeWrapper: TimeWrapper, logger: LoggerStream) {
+        this.cacheLogger = logger.createSubStream(CACHE_TAG);
+    }
+
+    async getCachedData<T>(params: {
+        invalidator: () => Promise<T>;
+        key: string;
+        refreshTime?: number;
+        shouldUpdateExpiry?: boolean;
+    }): Promise<T> {
+        const { invalidator, key, refreshTime, shouldUpdateExpiry } = params;
+        const cacheRefreshTime = refreshTime ?? this.timeWrapper.minutesInMillis(DEFAULT_REFRESH_TIME_IN_MIN);
+
+        const cacheData = this.cache.get(key);
+        if (!cacheData) {
+            // Cache not present, we need to enforce wait
+            this.cacheLogger.log('Cache not present enforcing wait');
+            return this.invalidateCache(cacheRefreshTime, invalidator, key);
+        }
+        if (shouldUpdateExpiry && cacheData.expiry > this.timeWrapper.getElapsedTime()) {
+            // When data is not expired, update it's expiry to future time.
+            cacheData.expiry = this.timeWrapper.getElapsedTime() + cacheRefreshTime;
+        }
+        if (cacheData.expiry <= this.timeWrapper.getElapsedTime() && cacheData.invalidate) {
+            this.cacheLogger.log(`Cache expired, sending request, locking invalidate for key "${key}"`);
+            cacheData.invalidate = false;
+            this.cache.set(key, cacheData);
+
+            return this.invalidateCache(cacheRefreshTime, invalidator, key);
+        }
+        this.cacheLogger.log(`Sending data from cache`);
+        return cacheData.data as T;
+    }
+
+    removeCachedData(key: string): boolean {
+        return this.cache.delete(key);
+    }
+
+    private async invalidateCache<T>(cacheRefreshTime: number, invalidator: () => Promise<T>, key: string): Promise<T> {
+        const newData = await invalidator();
+        if (newData) {
+            this.cacheLogger.log(`Updating data of cache for key "${key}"`);
+            this.cache.set(key, {
+                data: newData,
+                expiry: this.timeWrapper.getElapsedTime() + cacheRefreshTime,
+                invalidate: true,
+            });
+        }
+        return newData;
+    }
+}

--- a/src/data/db/MongoDBConnectionHandler.ts
+++ b/src/data/db/MongoDBConnectionHandler.ts
@@ -1,0 +1,160 @@
+import { Collection, Db, LoggerState, MongoClient } from 'mongodb';
+import LoggerStream from '../log/LoggerStream';
+import TimeWrapper from '../TimeWrapper';
+
+const BLACK_LISTED_MESSAGES = ['schedule getMore call'];
+const LOGGABLE_CLASS_NAME = ['Db', 'Cursor'];
+
+const RETRY_DELAY_IN_SEC = 5;
+const MAX_RETRY_ATTEMPT = 5;
+
+export default class MongoDBConnectionHandler {
+    private readonly mongoDbClients: MongoClient[] = [];
+    private readonly mongoDbLogger: (_?: string, loggerState?: LoggerState) => void;
+
+    constructor(
+        private readonly dbLogger: LoggerStream,
+        private readonly timeWrapper: TimeWrapper,
+        private readonly isDebug: boolean
+    ) {
+        this.mongoDbLogger = (_?: string, loggerState?: LoggerState): void => {
+            if (!isDebug || !loggerState) {
+                return;
+            }
+            for (let index = 0; index < BLACK_LISTED_MESSAGES.length; index++) {
+                const blackListedMessage = BLACK_LISTED_MESSAGES[index];
+                if (blackListedMessage && loggerState.message.startsWith(blackListedMessage)) {
+                    return;
+                }
+            }
+            if (LOGGABLE_CLASS_NAME.includes(loggerState.className)) {
+                this.dbLogger.log(loggerState);
+            }
+        };
+    }
+
+    connectDB(connectionUrl: string, retryAttempt: number = 0): void {
+        const mongoClient = new MongoClient(connectionUrl, {
+            loggerLevel: this.isDebug ? 'debug' : undefined,
+            logger: this.mongoDbLogger,
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+        });
+
+        mongoClient.on('connecting', () => this.dbLogger.log('connecting to MongoDB...'));
+        mongoClient.on('connected', () => this.dbLogger.log('MongoDB connected!'));
+        mongoClient.once('open', () => this.dbLogger.log('MongoDB connection opened!'));
+        mongoClient.on('reconnected', () => this.dbLogger.log('MongoDB reconnected!'));
+        mongoClient.on('error', (err: string) => {
+            this.dbLogger.error(`Error in MongoDb connection: ${err}`);
+            this.disconnectDB();
+            this.retryConnect(connectionUrl, retryAttempt);
+        });
+        mongoClient.on('disconnected', () => {
+            this.dbLogger.log('MongoDB disconnected!');
+            this.retryConnect(connectionUrl, retryAttempt);
+        });
+
+        mongoClient.connect().then(
+            () => {
+                this.dbLogger.log('DB connected');
+                this.mongoDbClients.push(mongoClient);
+            },
+            () => {
+                this.dbLogger.error('DB connection failed.');
+                this.retryConnect(connectionUrl, retryAttempt);
+            }
+        );
+    }
+
+    disconnectDB(): void {
+        while (this.mongoDbClients.length > 0) {
+            const client = this.mongoDbClients.pop();
+            if (client) {
+                client.close().then(
+                    () => this.dbLogger.log('DB disconnected'),
+                    () => this.dbLogger.error('DB disconnection failed.')
+                );
+            }
+        }
+    }
+
+    getAllDbCollections<T>(collectionName: string): Collection<T>[] {
+        return this.mongoDbClients.map((client) => client.db().collection<T>(collectionName));
+    }
+
+    getPrimaryDb(): Db {
+        if (this.mongoDbClients.length > 0 && this.mongoDbClients[0]) {
+            return this.mongoDbClients[0].db();
+        }
+        throw new Error(`No Primary DB specified`);
+    }
+
+    getPrimaryDbCollection<T>(collectionName: string): Collection<T> {
+        return this.getPrimaryDb().collection<T>(collectionName);
+    }
+
+    lazyBackupOp<COLLECTION_TYPE, OPERATION_RESULT_TYPE>(
+        collections: Collection<COLLECTION_TYPE>[],
+        executor: (collection: Collection<COLLECTION_TYPE>) => Promise<OPERATION_RESULT_TYPE>
+    ): Promise<OPERATION_RESULT_TYPE> {
+        const primaryDb = collections[0];
+        if (!primaryDb) {
+            return Promise.reject(new Error(`Invalid call for DB operation`));
+        }
+        const logOperationPerformance = (
+            collection: string,
+            status: 'success' | 'failed',
+            executionTime: number
+        ): void => this.dbLogger.log(`DB Performance: `, { collection, status, executionTime });
+        return new Promise<OPERATION_RESULT_TYPE>((resolve, reject) => {
+            const executorStartTimeForPrimaryCollection = this.timeWrapper.getDate().getTime();
+            executor(primaryDb).then(
+                (data) => {
+                    const executionTimeForPrimaryCollection =
+                        this.timeWrapper.getElapsedTime() - executorStartTimeForPrimaryCollection;
+                    logOperationPerformance('primary', 'success', executionTimeForPrimaryCollection);
+
+                    // Execute operation on backup DB, only when primary DB operation sucess.
+                    for (let index = 1; index < collections.length; index++) {
+                        const collection = collections[index];
+                        if (collection) {
+                            const executorStartTimeForBackupCollection = this.timeWrapper.getElapsedTime();
+                            const logPerformance = (status: 'success' | 'failed'): void => {
+                                const executionTimeForBackupCollection =
+                                    this.timeWrapper.getElapsedTime() - executorStartTimeForBackupCollection;
+                                logOperationPerformance(`backup_${index}`, status, executionTimeForBackupCollection);
+                            };
+                            executor(collection).then(
+                                () => logPerformance('success'),
+                                (err) => {
+                                    logPerformance('failed');
+                                    this.dbLogger.error(`DB Operation error for backup_${index} collection`, err);
+                                }
+                            );
+                        }
+                    }
+                    resolve(data);
+                },
+                (err) => {
+                    const executionTimeForPrimaryCollection =
+                        this.timeWrapper.getElapsedTime() - executorStartTimeForPrimaryCollection;
+                    logOperationPerformance('primary', 'failed', executionTimeForPrimaryCollection);
+                    this.dbLogger.error(`DB Operation error for primary collection`, err);
+                    reject(err);
+                }
+            );
+        });
+    }
+
+    private retryConnect(connectionUrl: string, retryAttempt: number = 0): void {
+        if (retryAttempt >= MAX_RETRY_ATTEMPT) {
+            this.dbLogger.error('Hit max retry attempts');
+            return;
+        }
+        setTimeout(
+            () => this.connectDB(connectionUrl, retryAttempt + 1),
+            this.timeWrapper.secondsInMillis(RETRY_DELAY_IN_SEC)
+        );
+    }
+}

--- a/src/data/db/helper/DbHelper.ts
+++ b/src/data/db/helper/DbHelper.ts
@@ -1,0 +1,20 @@
+import { Collection } from 'mongodb';
+import MongoDBConnectionHandler from '../MongoDBConnectionHandler';
+
+export const isSuccessDBResult = (operationResult: { ok?: number; result?: { ok?: number } }): boolean =>
+    (operationResult.result?.ok ?? operationResult.ok) === 1;
+
+export abstract class DbHelper<T> {
+    protected constructor(
+        protected readonly dbConnectionHandler: MongoDBConnectionHandler,
+        private readonly collectionName: string
+    ) {}
+
+    protected getAllCollections(): Collection<T>[] {
+        return this.dbConnectionHandler.getAllDbCollections<T>(this.collectionName);
+    }
+
+    protected getPrimaryCollection(): Collection<T> {
+        return this.dbConnectionHandler.getPrimaryDbCollection<T>(this.collectionName);
+    }
+}


### PR DESCRIPTION
- Added the MongoDbConnectionHandler to connect and manage multiple
  MongoDB connnections.
- Many devs prefer to have a self managed MongoDB instance with a backup
  mongoDB server instead of handling complexity of setting up the mongoDB
  clusters.
- The mongoDB connection handler considers first db connection as a primary
  DB connection. Whereas, it considers subsequent mongoDB connections as
  a backup DB connection.
- Devs could choose to read data from primary DB as a performance benefit.
  Also they could perform write/update data simultaneously in primary and
  backup DBs to have latest Data in backup DB.
- Also, added the cache manager to store the DB data in in-memory cache for
  certain amount of time to avoid refetching same data from DB multiple times.
- Also, added BuildConfig to store all the configuration (a.k.a. environment
  variables).
- Also, created the data dependencies class, which would be used by services
  to perform their tasks.

Github Issue: https://github.com/mr-ashok/modern-nodejs-api-architecture/issues/5